### PR TITLE
Implement IDeletableXmlRepository

### DIFF
--- a/src/VaultSharpDataProtection.Test/VaultSharpXmlRepositoryTests.cs
+++ b/src/VaultSharpDataProtection.Test/VaultSharpXmlRepositoryTests.cs
@@ -4,46 +4,162 @@ using VaultSharp.V1.AuthMethods.Token;
 using VaultSharp;
 using Xunit;
 using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.DataProtection.Repositories;
 
 namespace VaultSharpDataProtection.Test;
 public class VaultSharpXmlRepositoryTests
 {
     private const string _vaultUri = "http://localhost:8200";
-    private const string _token = "hvs.*********************";
+    private const string _token = "hvs.";
     private const string _path = "Keys";
     private const string _mountPoint = "data-protection";
 
     [Fact(Skip = "Requires a running Vault server")]
-    public void StoreAndRetrieveKey_ShouldSucceed()
+    public async Task StoreAndRetrieveKey_ShouldSucceed()
     {
-        var vaultClient = new VaultClient(new VaultClientSettings(_vaultUri, new TokenAuthMethodInfo(_token)));
-        var repository = new VaultSharpXmlRepository(vaultClient, _path, _mountPoint);
+        await WithVaultCleanup((repository) =>
+        {
+            var keyXml = """
+                <key id="d17a439d-8228-4216-9ea5-16a5424a0788" version="1">
+                    <creationDate>2024-12-19T10:20:37.0840255Z</creationDate>
+                    <activationDate>2024-12-19T10:20:30.6281791Z</activationDate>
+                    <expirationDate>2024-12-26T10:20:30.6281791Z</expirationDate>
+                    <descriptor deserializerType="Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+                        <descriptor>
+                            <encryption algorithm="AES_256_CBC" />
+                            <validation algorithm="HMACSHA256" />
+                            <masterKey p4:requiresEncryption="true" xmlns:p4="http://schemas.asp.net/2015/03/dataProtection">
+                                <value>wlZYX34JjRFEz+1vGZPUI/2hbR5oKtxcq58qh8i2eO7CjdQGuyd3U6+tRIUe1Qzww3kOHZ30Tz8BPcd3nsFEgg==</value>
+                            </masterKey>
+                        </descriptor>
+                    </descriptor>
+                </key>
+                """;
 
-        var keyXml = """
-        <key id="d17a439d-8228-4216-9ea5-16a5424a0788" version="1">
-            <creationDate>2024-12-19T10:20:37.0840255Z</creationDate>
-            <activationDate>2024-12-19T10:20:30.6281791Z</activationDate>
-            <expirationDate>2024-12-26T10:20:30.6281791Z</expirationDate>
-            <descriptor deserializerType="Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel.AuthenticatedEncryptorDescriptorDeserializer, Microsoft.AspNetCore.DataProtection, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-                <descriptor>
-                    <encryption algorithm="AES_256_CBC" />
-                    <validation algorithm="HMACSHA256" />
-                    <masterKey p4:requiresEncryption="true" xmlns:p4="http://schemas.asp.net/2015/03/dataProtection">
-                        <value>wlZYX34JjRFEz+1vGZPUI/2hbR5oKtxcq58qh8i2eO7CjdQGuyd3U6+tRIUe1Qzww3kOHZ30Tz8BPcd3nsFEgg==</value>
-                    </masterKey>
-                </descriptor>
-            </descriptor>
-        </key>
-        """;
+            var element = XElement.Parse(keyXml);
+            var friendlyName = $"key-{Guid.NewGuid()}";
+            repository.StoreElement(element, friendlyName);
 
-        var element = XElement.Parse(keyXml);
-        var friendlyName = $"key-{Guid.NewGuid()}";
-        repository.StoreElement(element, friendlyName);
+            var retrievedElements = repository.GetAllElements();
+            Assert.NotNull(retrievedElements);
+            Assert.Single(retrievedElements);
+            var retrievedElement = retrievedElements.First();
+            Assert.Equal(element.ToString(SaveOptions.DisableFormatting), retrievedElement.ToString(SaveOptions.DisableFormatting));
+        });
+    }
 
-        var retrievedElements = repository.GetAllElements();
-        Assert.NotNull(retrievedElements);
-        Assert.Single(retrievedElements);
-        var retrievedElement = retrievedElements.First();
-        Assert.Equal(element.ToString(SaveOptions.DisableFormatting), retrievedElement.ToString(SaveOptions.DisableFormatting));
+    [Theory(Skip = "Requires a running Vault server")]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task DeleteElements(bool delete1, bool delete2)
+    {
+        await WithVaultCleanup((repository) =>
+        {
+            var key1 = Guid.NewGuid().ToString();
+            var key1Element = XElement.Parse($"""<key id="{key1}" version="1"></key>""");
+            repository.StoreElement(key1Element, friendlyName: $"key-{key1}");
+
+            var key2 = Guid.NewGuid().ToString();
+            var key2Element = XElement.Parse($"""<key id="{key2}" version="2"></key>""");
+            repository.StoreElement(key2Element, friendlyName: $"key-{key2}");
+
+            var ranSelector = false;
+
+            var deletionResult = repository.DeleteElements(deletableElements =>
+            {
+                ranSelector = true;
+                Assert.Equal(2, deletableElements.Count);
+
+                foreach (var element in deletableElements)
+                {
+                    string id = element.Element.Attribute("id").Value;
+                    if (key1.Equals(id))
+                    {
+                        element.DeletionOrder = delete1 ? 1 : null;
+                    }
+
+                    if (key2.Equals(id))
+                    {
+                        element.DeletionOrder = delete2 ? 2 : null;
+                    }
+                }
+            });
+
+            Assert.True(deletionResult);
+            Assert.True(ranSelector);
+
+            var elementSet = new HashSet<string>(repository.GetAllElements().Select(e => e.Attribute("id").Value));
+
+            Assert.InRange(elementSet.Count, 0, 2);
+
+            Assert.Equal(!delete1, elementSet.Contains(key1));
+            Assert.Equal(!delete2, elementSet.Contains(key2));
+        });
+    }
+
+    [Fact(Skip = "Requires a running Vault server")]
+    public async Task DeleteElementsWithOutOfBandDeletion()
+    {
+        await WithVaultCleanup((repository, client) =>
+        {
+            var key1 = Guid.NewGuid().ToString();
+            var key1Element = XElement.Parse($"""<key id="{key1}" version="1"></key>""");
+            repository.StoreElement(key1Element, friendlyName: $"key-{key1}");
+
+
+            var elements = repository.GetAllElements();
+            Assert.NotNull(elements);
+            Assert.True(elements.Count == 1);
+            Assert.Contains(elements, e => e.Attribute("id")?.Value == key1);
+
+            var ranSelector = false;
+            var deletionResult = repository.DeleteElements(deletableElements =>
+            {
+                ranSelector = true;
+                client.V1.Secrets.KeyValue.V2.DeleteSecretVersionsAsync(_path, [1], _mountPoint).GetAwaiter().GetResult();
+                Assert.Single(deletableElements);
+                deletableElements.First().DeletionOrder = 1;
+            });
+
+            Assert.True(deletionResult);
+            Assert.True(ranSelector);
+
+            var remainingElements = repository.GetAllElements();
+            Assert.DoesNotContain(remainingElements, e => e.Attribute("id")?.Value == key1);
+        });
+    }
+
+    private static async Task WithVaultCleanup(Action<IDeletableXmlRepository> testCode)
+    {
+        VaultClient client = new(new VaultClientSettings(_vaultUri, new TokenAuthMethodInfo(_token)));
+        try
+        {
+            await client.V1.Secrets.KeyValue.V2.DeleteMetadataAsync(_path, _mountPoint);
+            var repository = new VaultSharpXmlRepository(client, _path, _mountPoint);
+            testCode(repository);
+        }
+        finally
+        {
+            await client.V1.Secrets.KeyValue.V2.DeleteMetadataAsync(_path, _mountPoint);
+        }
+    }
+
+    private static async Task WithVaultCleanup(Action<IDeletableXmlRepository, VaultClient> testCode)
+    {
+        VaultClient client = new(new VaultClientSettings(_vaultUri, new TokenAuthMethodInfo(_token)));
+        try
+        {
+            await client.V1.Secrets.KeyValue.V2.DeleteMetadataAsync(_path, _mountPoint);
+            var repository = new VaultSharpXmlRepository(client, _path, _mountPoint);
+            testCode(repository, client);
+        }
+        finally
+        {
+            await client.V1.Secrets.KeyValue.V2.DeleteMetadataAsync(_path, _mountPoint);
+        }
     }
 }

--- a/src/VaultSharpDataProtection/VaultSharpDataProtection.csproj
+++ b/src/VaultSharpDataProtection/VaultSharpDataProtection.csproj
@@ -12,10 +12,11 @@
     <RepositoryUrl>https://github.com/PaulHatch/vault-data-protection.git</RepositoryUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>latest</LangVersion>
+	<Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="9.0.0" />
     <PackageReference Include="VaultSharp" Version="1.17.5.1" />
     <None Include="..\..\icon.png" Pack="true" PackagePath="\"/>
   </ItemGroup>

--- a/src/VaultSharpDataProtection/VaultSharpXmlRepository.cs
+++ b/src/VaultSharpDataProtection/VaultSharpXmlRepository.cs
@@ -8,6 +8,7 @@ using System.Xml.Linq;
 using Microsoft.AspNetCore.DataProtection.Repositories;
 using VaultSharp;
 using VaultSharp.Core;
+using VaultSharp.V1.SecretsEngines.KeyValue.V2;
 
 namespace VaultSharpDataProtection;
 
@@ -16,10 +17,10 @@ namespace VaultSharpDataProtection;
 /// data protection keys in Vault using the VaultSharp client.
 /// </summary>
 /// <seealso cref="Microsoft.AspNetCore.DataProtection.Repositories.IXmlRepository" />
-public class VaultSharpXmlRepository : IXmlRepository
+public class VaultSharpXmlRepository : IDeletableXmlRepository
 {
     private static readonly TaskFactory _factory =
-        new TaskFactory(
+        new(
             CancellationToken.None,
             TaskCreationOptions.None,
             TaskContinuationOptions.None,
@@ -28,6 +29,7 @@ public class VaultSharpXmlRepository : IXmlRepository
     private readonly IVaultClient _vault;
     private readonly string _path;
     private readonly string _mountPoint;
+    private readonly IKeyValueSecretsEngineV2 _v2Api;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="VaultSharpXmlRepository"/> class.
@@ -38,6 +40,7 @@ public class VaultSharpXmlRepository : IXmlRepository
     public VaultSharpXmlRepository(IVaultClient vault, string path, string mountPoint)
     {
         _vault = vault;
+        _v2Api = _vault.V1.Secrets.KeyValue.V2;
         _path = path;
         _mountPoint = mountPoint;
     }
@@ -48,18 +51,12 @@ public class VaultSharpXmlRepository : IXmlRepository
     {
         try
         {
-            var response = RunSync(() => _vault.V1.Secrets.KeyValue.V2.ReadSecretAsync(_path, null, _mountPoint));
-            return response.Data.Data.Values.Select(e => e switch
-            {
-                string v => XElement.Parse(v),
-                JsonElement { ValueKind: JsonValueKind.String } j when j.GetString() is {} s => XElement.Parse(s),
-                _ => throw new InvalidCastException($"Expected JSON string, but got {e.GetType()}.")
-            }).ToList()
-              .AsReadOnly();
+            var response = RunSync(async () => await _v2Api.ReadSecretAsync(_path, null, _mountPoint));
+            return response.Data.Data.Values.Select(ParseElement).ToList().AsReadOnly();
         }
         catch (VaultApiException e) when (e.StatusCode == 404)
         {
-            return Array.Empty<XElement>();
+            return [];
         }
     }
 
@@ -72,7 +69,7 @@ public class VaultSharpXmlRepository : IXmlRepository
             IDictionary<string, object> value;
             try
             {
-                var response = await _vault.V1.Secrets.KeyValue.V2.ReadSecretAsync(_path, null, _mountPoint);
+                var response = await _v2Api.ReadSecretAsync(_path, null, _mountPoint);
                 version = response.Data.Metadata.Version;
                 value = response.Data.Data;
             }
@@ -83,24 +80,100 @@ public class VaultSharpXmlRepository : IXmlRepository
             }
 
             value[friendlyName] = element.ToString(SaveOptions.DisableFormatting);
-
-            await _vault.V1.Secrets.KeyValue.V2.WriteSecretAsync(_path, value, version, _mountPoint);
+            await _v2Api.WriteSecretAsync(_path, value, version, _mountPoint);
         });
     }
 
     private static T RunSync<T>(Func<Task<T>> method)
     {
         return _factory.StartNew(method)
-            .Unwrap()
-            .GetAwaiter()
-            .GetResult();
+                       .Unwrap()
+                       .GetAwaiter()
+                       .GetResult();
     }
 
     private static void RunSync(Func<Task> method)
     {
         _factory.StartNew(method)
-            .Unwrap()
-            .GetAwaiter()
-            .GetResult();
+                .Unwrap()
+                .GetAwaiter()
+                .GetResult();
+    }
+
+    /// <inheritdoc/>
+    public bool DeleteElements(Action<IReadOnlyCollection<IDeletableElement>> chooseElements)
+    {
+        ArgumentNullException.ThrowIfNull(chooseElements);
+        try
+        {
+            return RunSync(async () =>
+            {
+                var response = await _v2Api.ReadSecretAsync(_path, null, _mountPoint);
+                int currentVersion = response.Data.Metadata.Version;
+                IDictionary<string, object> value = response.Data.Data;
+
+                if (value.Count < 1 || currentVersion < 1)
+                {
+                    return false;
+                }
+
+                var deletableElements = value.Select(kv =>
+                {
+                    XElement element = ParseElement(kv.Value);
+                    var id = element.Attribute("id")?.Value;
+                    if (string.IsNullOrWhiteSpace(id) || id.Equals(kv.Key.Remove(0, 4), StringComparison.OrdinalIgnoreCase) is false)
+                    {
+                        throw new InvalidOperationException("Element is missing the 'id' attribute.");
+                    }
+                    return new DeletableElement(kv.Key, element);
+                }).ToList();
+
+                chooseElements(deletableElements);
+
+                var elementsToDelete = deletableElements.Where(e => e.DeletionOrder.HasValue)
+                                                        .OrderBy(e => e.DeletionOrder.GetValueOrDefault())
+                                                        .ToList();
+
+                if (elementsToDelete is not null && elementsToDelete.Count > 0)
+                {
+                    foreach (var element in elementsToDelete)
+                    {
+                        value.Remove(element.Key);
+                    }
+                    List<int> versionsToDelete = Enumerable.Range(1, currentVersion).ToList();
+                    try
+                    {
+                        await _v2Api.DeleteSecretVersionsAsync(_path, versionsToDelete, _mountPoint);
+                        await _v2Api.WriteSecretAsync(_path, value, currentVersion, _mountPoint);
+                    }
+                    catch
+                    {
+                        await _v2Api.UndeleteSecretVersionsAsync(_path, versionsToDelete, _mountPoint);
+                        return false;
+                    }
+                }
+                return true;
+            });
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static XElement ParseElement(object value)
+    {
+        return value switch
+        {
+            string v => XElement.Parse(v),
+            JsonElement { ValueKind: JsonValueKind.String } j when j.GetString() is { } s => XElement.Parse(s),
+            _ => throw new InvalidCastException($"Expected JSON string, but got {value.GetType()}.")
+        };
+    }
+    private sealed class DeletableElement(string key, XElement element) : IDeletableElement
+    {
+        public XElement Element { get; } = element;
+        public string Key { get; } = key;
+        public int? DeletionOrder { get; set; }
     }
 }


### PR DESCRIPTION
Hi,

First, we delete all existing secret versions at the specified path, then add a new version with the updated data, excluding the keys marked for deletion. If the latest version cannot be written, we undelete the previously deleted versions to maintain data integrity and ensure a safe and clean update process

Based on:

https://github.com/dotnet/aspnetcore/pull/53860

https://github.com/dotnet/aspnetcore/blob/f7ff82f6674ae31c638d82aab86604b94b88766b/src/DataProtection/DataProtection/src/Repositories/RegistryXmlRepository.cs#L160

https://github.com/dotnet/aspnetcore/blob/f7ff82f6674ae31c638d82aab86604b94b88766b/src/DataProtection/DataProtection/src/Repositories/EphemeralXmlRepository.cs#L59

https://github.com/dotnet/aspnetcore/blob/f7ff82f6674ae31c638d82aab86604b94b88766b/src/DataProtection/DataProtection/src/Repositories/RegistryXmlRepository.cs#L160

______________________

![image](https://github.com/user-attachments/assets/ed1ab2b1-08f3-496c-bdae-f204248f8c63)

Related to : https://github.com/PaulHatch/vault-data-protection/issues/1